### PR TITLE
fix(docker): bump npm to 11.14.1 to resolve CVE-2026-42338

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,9 @@ RUN npm install -g npm@11.11.0 && \
     npm pack tar@7.5.11 && \
     tar -xzf tar-7.5.11.tgz -C /usr/local/lib/node_modules/npm/node_modules/tar --strip-components=1 && \
     rm tar-7.5.11.tgz && \
+    npm pack ip-address@10.2.0 && \
+    tar -xzf ip-address-10.2.0.tgz -C /usr/local/lib/node_modules/npm/node_modules/ip-address --strip-components=1 && \
+    rm ip-address-10.2.0.tgz && \
     npm cache clean --force
 
 # Set working directory
@@ -47,6 +50,9 @@ RUN npm install -g npm@11.11.0 && \
     npm pack tar@7.5.11 && \
     tar -xzf tar-7.5.11.tgz -C /usr/local/lib/node_modules/npm/node_modules/tar --strip-components=1 && \
     rm tar-7.5.11.tgz && \
+    npm pack ip-address@10.2.0 && \
+    tar -xzf ip-address-10.2.0.tgz -C /usr/local/lib/node_modules/npm/node_modules/ip-address --strip-components=1 && \
+    rm ip-address-10.2.0.tgz && \
     npm cache clean --force
 
 # Upgrade base packages (fixes zlib CVEs) and install runtime dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,13 @@
 FROM node:24-alpine AS builder
 
 # Upgrade npm and patch its bundled dependencies to fix known CVEs
-RUN npm install -g npm@11.11.0 && \
+RUN npm install -g npm@11.14.1 && \
     npm pack minimatch@10.2.4 && \
     tar -xzf minimatch-10.2.4.tgz -C /usr/local/lib/node_modules/npm/node_modules/minimatch --strip-components=1 && \
     rm minimatch-10.2.4.tgz && \
     npm pack tar@7.5.11 && \
     tar -xzf tar-7.5.11.tgz -C /usr/local/lib/node_modules/npm/node_modules/tar --strip-components=1 && \
     rm tar-7.5.11.tgz && \
-    npm pack ip-address@10.2.0 && \
-    tar -xzf ip-address-10.2.0.tgz -C /usr/local/lib/node_modules/npm/node_modules/ip-address --strip-components=1 && \
-    rm ip-address-10.2.0.tgz && \
     npm cache clean --force
 
 # Set working directory
@@ -43,16 +40,13 @@ RUN npm run build:docker
 FROM node:24-alpine AS runtime
 
 # Upgrade npm and patch its bundled dependencies to fix known CVEs
-RUN npm install -g npm@11.11.0 && \
+RUN npm install -g npm@11.14.1 && \
     npm pack minimatch@10.2.4 && \
     tar -xzf minimatch-10.2.4.tgz -C /usr/local/lib/node_modules/npm/node_modules/minimatch --strip-components=1 && \
     rm minimatch-10.2.4.tgz && \
     npm pack tar@7.5.11 && \
     tar -xzf tar-7.5.11.tgz -C /usr/local/lib/node_modules/npm/node_modules/tar --strip-components=1 && \
     rm tar-7.5.11.tgz && \
-    npm pack ip-address@10.2.0 && \
-    tar -xzf ip-address-10.2.0.tgz -C /usr/local/lib/node_modules/npm/node_modules/ip-address --strip-components=1 && \
-    rm ip-address-10.2.0.tgz && \
     npm cache clean --force
 
 # Upgrade base packages (fixes zlib CVEs) and install runtime dependencies


### PR DESCRIPTION
## Summary

- Bumps npm from `11.11.0` → `11.14.1` in both builder and runtime stages
- npm 11.14.1 bundles `ip-address 10.1.1` (via `socks → socks-proxy-agent → @npmcli/agent`), which fixes CVE-2026-42338
- Resolves code scanning alert #135
- No manual patching needed — this is the proper fix via the npm upgrade itself

## CVE Details

**CVE-2026-42338** (MEDIUM): XSS in `ip-address` `Address6` HTML-emitting methods.  
**Chain**: npm → `@npmcli/agent` → `socks-proxy-agent` → `socks` → `ip-address`  
npm 11.14.1 ships with `socks@2.8.8` which requires `ip-address ^10.1.1`, resolving to `10.1.1`.

## Test plan
- [ ] CI passes (Trivy scan should no longer flag `ip-address 10.1.0`)
- [ ] Code scanning alert #135 closes after merge