### PR TITLE
feat: layer sidereal workflow on superpowers via skills + hooks

### DIFF
--- a/.claude/hooks/check-edit-prerequisites.sh
+++ b/.claude/hooks/check-edit-prerequisites.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Edit/Write/NotebookEdit.
+# Warn-only: emits a system message but never blocks.
+#
+# Checks (in order; missing prerequisites accumulate into one warning):
+#   1. Current branch matches `issue-<n>-*` (not on main, not on a non-issue branch)
+#   2. The referenced issue has the `spec/ready` label
+#   3. A plan file exists at `.workspace/plans/*issue-<n>*.md`
+#
+# Reads the tool call payload from stdin; emits warnings to stderr; exits 0 always.
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cd "$REPO_ROOT" || exit 0
+
+# Read payload (we don't need to inspect it for path filtering — gating is global)
+cat > /dev/null
+
+branch="$(git branch --show-current 2>/dev/null)"
+[[ -z "$branch" ]] && exit 0  # detached HEAD or no branch — skip
+
+warnings=()
+
+# --- Check 1: branch name pattern ---
+if [[ ! "$branch" =~ ^issue-([0-9]+)- ]]; then
+  if [[ "$branch" == "main" || "$branch" == "master" ]]; then
+    warnings+=("editing on \`$branch\` — sidereal workflow expects an \`issue-<n>-<slug>\` branch off origin/main")
+  else
+    warnings+=("branch \`$branch\` does not match \`issue-<n>-<slug>\` — sidereal workflow expects issue-scoped branches")
+  fi
+  # Without an issue number we can't run checks 2 and 3.
+  if [[ ${#warnings[@]} -gt 0 ]]; then
+    printf '\n[sidereal-workflow] Heads up:\n' >&2
+    for w in "${warnings[@]}"; do printf '  - %s\n' "$w" >&2; done
+    printf '  See the sidereal-workflow-overrides skill for the full workflow.\n\n' >&2
+  fi
+  exit 0
+fi
+
+issue_num="${BASH_REMATCH[1]}"
+
+# --- Check 2: spec/ready label (cached per branch) ---
+cache_dir=".workspace/cache/label-cache"
+mkdir -p "$cache_dir"
+cache_file="$cache_dir/$(echo "$branch" | tr '/' '_')"
+
+if [[ -f "$cache_file" ]]; then
+  has_label="$(cat "$cache_file")"
+else
+  if command -v gh >/dev/null 2>&1; then
+    labels="$(gh issue view "$issue_num" --json labels --jq '[.labels[].name] | join(",")' 2>/dev/null)"
+    if [[ -z "$labels" ]]; then
+      has_label="unknown"  # gh failed (network, auth, or issue doesn't exist)
+    elif [[ ",$labels," == *",spec/ready,"* ]]; then
+      has_label="yes"
+    else
+      has_label="no:$labels"
+    fi
+    echo "$has_label" > "$cache_file"
+  else
+    has_label="unknown"
+  fi
+fi
+
+case "$has_label" in
+  yes)         ;;  # all good
+  unknown)     warnings+=("could not verify issue #$issue_num labels (gh failed) — make sure it has \`spec/ready\` before implementing") ;;
+  no:*)        warnings+=("issue #$issue_num is missing the \`spec/ready\` label (current labels: ${has_label#no:}) — only humans should apply it") ;;
+esac
+
+# --- Check 3: plan file exists ---
+shopt -s nullglob
+plans=( .workspace/plans/*"issue-${issue_num}"*.md )
+shopt -u nullglob
+if [[ ${#plans[@]} -eq 0 ]]; then
+  warnings+=("no plan file found at \`.workspace/plans/*issue-${issue_num}*.md\` — sidereal workflow expects a plan before implementation")
+fi
+
+# --- Emit ---
+if [[ ${#warnings[@]} -gt 0 ]]; then
+  printf '\n[sidereal-workflow] Heads up (warn-only):\n' >&2
+  for w in "${warnings[@]}"; do printf '  - %s\n' "$w" >&2; done
+  printf '  See the sidereal-workflow-overrides skill for the full workflow.\n' >&2
+  printf '  To clear the label cache: rm -rf .workspace/cache/label-cache\n\n' >&2
+fi
+
+exit 0

--- a/.claude/hooks/check-pr-closes-issue.sh
+++ b/.claude/hooks/check-pr-closes-issue.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# PreToolUse hook for Bash. Inspects `gh pr create` invocations to ensure the
+# PR body includes `Closes #<n>` matching the current issue branch.
+#
+# Warn-only: emits a system message but never blocks.
+#
+# Reads the tool call payload from stdin (JSON with .tool_input.command).
+
+set -uo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cd "$REPO_ROOT" || exit 0
+
+payload="$(cat)"
+command="$(printf '%s' "$payload" | jq -r '.tool_input.command // empty' 2>/dev/null)"
+[[ -z "$command" ]] && exit 0
+
+# Only inspect `gh pr create` calls
+[[ "$command" != *"gh pr create"* ]] && exit 0
+
+branch="$(git branch --show-current 2>/dev/null)"
+if [[ ! "$branch" =~ ^issue-([0-9]+)- ]]; then
+  printf '\n[sidereal-workflow] Heads up: creating a PR from \`%s\` (no issue-<n>-* prefix). PR will not auto-close any issue.\n\n' "$branch" >&2
+  exit 0
+fi
+
+issue_num="${BASH_REMATCH[1]}"
+
+# The body may be inline (`--body "..."`), via heredoc (`--body "$(cat <<EOF ... EOF)"`),
+# or via file (`--body-file path`). For warn-only, a substring search across the whole
+# command captures the inline + heredoc cases. --body-file we flag separately.
+if [[ "$command" == *"--body-file"* ]]; then
+  printf '\n[sidereal-workflow] Heads up: PR uses --body-file. Verify it contains \`Closes #%s\` so the issue auto-closes on merge.\n\n' "$issue_num" >&2
+  exit 0
+fi
+
+# Match `Closes #N`, `closes #N`, `Fixes #N`, `Resolves #N` — all of GitHub's auto-close keywords
+if ! printf '%s' "$command" | grep -qiE '(close[sd]?|fix(es|ed)?|resolve[sd]?)[[:space:]]+#'"$issue_num"'\b'; then
+  printf '\n[sidereal-workflow] Heads up (warn-only):\n' >&2
+  printf '  - PR body does not contain \`Closes #%s\` — issue will not auto-close on merge.\n' "$issue_num" >&2
+  printf '  - Add a line like \`Closes #%s\` to the PR body.\n\n' "$issue_num" >&2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,27 @@
 {
   "enabledPlugins": {
     "superpowers@claude-plugins-official": true
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-edit-prerequisites.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-pr-closes-issue.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/sidereal-pick-next-issue/SKILL.md
+++ b/.claude/skills/sidereal-pick-next-issue/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: sidereal-pick-next-issue
+description: Use when the user asks "what's next?", "what should I work on?", "find me an issue", "pick something to do", or starts a workflow without naming a specific issue. Surveys the GitHub issue queue, recommends the highest-priority `spec/ready` issue, and lists alternatives plus the `spec/brainstorming` queue.
+---
+
+# Pick the Next Issue
+
+Help the user choose what to work on next by surveying the GitHub issue queue and recommending one issue, with alternatives.
+
+## When to invoke
+
+- User asks "what's next?", "what should I work on?", "anything to do?"
+- User asks to start the workflow without naming an issue ("let's do the next one", "start something")
+- User invokes `sidereal-workflow-overrides` or superpowers brainstorming/writing-plans without specifying an issue number
+
+## Process
+
+### Step 1 — Query both queues in parallel
+
+```bash
+gh issue list --label spec/ready          --json number,title,labels,createdAt,url --limit 50
+gh issue list --label spec/brainstorming  --json number,title,labels,createdAt,url --limit 50
+```
+
+### Step 2 — Rank `spec/ready` candidates
+
+Sort by priority label, then by age (oldest first within a tier):
+
+1. `priority:high`
+2. `priority:medium`
+3. `priority:low`
+4. (no priority label)
+
+Within each tier, oldest `createdAt` wins.
+
+### Step 3 — Present results
+
+Format the response as three sections. Keep it scannable.
+
+```markdown
+**Recommended:** #<n> — <title>
+Priority: <label or "unlabeled"> · Opened <relative date> · <url>
+
+<one-sentence reason for the recommendation, e.g. "highest priority and oldest in the spec/ready queue">
+
+**Other spec/ready issues:**
+- #<n> — <title> (priority:<x>, opened <date>)
+- #<n> — <title> (...)
+
+**Brainstorming queue (needs refinement before implementation):**
+- #<n> — <title> (opened <date>)
+- #<n> — <title> (...)
+```
+
+If a section is empty, say so explicitly ("No issues in the brainstorming queue.") rather than omitting the heading.
+
+### Step 4 — Hand off
+
+Ask: "Want me to start on #<n>, or pick a different one?"
+
+If the user picks an `spec/ready` issue:
+- Invoke `sidereal-workflow-overrides` and start at Override 2 (branch creation), since the issue is already approved.
+
+If the user picks a `spec/brainstorming` issue:
+- Invoke `superpowers:brainstorming` with `sidereal-workflow-overrides` layered on top, starting at Override 1 (continue refining the issue body).
+
+If both queues are empty:
+- Report that. Suggest the user open a new issue with the `spec/brainstorming` label to start a fresh design.
+
+## Edge cases
+
+- **`gh` not authenticated:** Report the error verbatim and suggest `gh auth login`. Do not try to recover.
+- **An issue has both `spec/brainstorming` and `spec/ready` labels:** Treat as `spec/ready` (the human-applied label wins) and flag the inconsistency to the user.
+- **Issue assigned to someone else:** Still surface it but note the assignee. Don't filter it out — the user may be coordinating.

--- a/.claude/skills/sidereal-workflow-overrides/SKILL.md
+++ b/.claude/skills/sidereal-workflow-overrides/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: sidereal-workflow-overrides
+description: Use whenever the superpowers brainstorming, writing-plans, or finishing-a-development-branch skills would apply in the sidereal repo. Defines four project-specific overrides on top of the standard superpowers workflow — spec lives on a GitHub issue, plans live in `.workspace/plans/`, an ADR may be required before PR, and the PR body must close the issue.
+---
+
+# Sidereal Workflow Overrides
+
+This skill is an **overlay** on the superpowers workflow. Follow the standard `superpowers:brainstorming`, `superpowers:writing-plans`, `superpowers:executing-plans` (or `subagent-driven-development`), and `superpowers:finishing-a-development-branch` skills as written, with the four overrides below.
+
+If a step here conflicts with a superpowers skill, this skill wins (per superpowers' own "user instructions take precedence" rule).
+
+## Override 1 — Spec lives on a GitHub issue
+
+**Replaces:** `spec/brainstorming` Step 6 ("Write design doc to `docs/superpowers/specs/...`") and Step 8 ("User reviews the spec file").
+
+In sidereal, the spec is the GitHub issue body, not a local file. The brainstorming dialogue, design proposals, and final spec all land on the issue.
+
+```bash
+# New idea
+gh issue create --title "<title>" --label spec/brainstorming --body "<spec body>"
+
+# Existing issue
+gh issue edit <number> --add-label spec/brainstorming
+gh issue edit <number> --body-file -   # update body from stdin
+```
+
+The user iterates on the issue. **Do not proceed to implementation until a human applies the `spec/ready` label** — never set this label yourself. Visual mockups belong as issue attachments.
+
+The "user reviews the spec" gate becomes: "user applies `spec/ready` label."
+
+## Override 2 — Branch naming and plan location
+
+**Adds:** a step between `spec/brainstorming` and `writing-plans`.
+
+Once the issue is `spec/ready`:
+
+```bash
+gh issue list --label spec/ready    # confirm what's ready
+git fetch origin
+git checkout -b issue-<number>-<short-slug> origin/main
+```
+
+**Replaces:** `writing-plans` save location.
+
+Save the plan to `.workspace/plans/YYYY-MM-DD-issue-<number>-<slug>.md` (gitignored — plans are working documents). Include the issue URL at the top of the plan, immediately after the required superpowers header block.
+
+## Override 3 — Verification cadence
+
+**Adds:** to the per-task TDD loop.
+
+After each task's test+commit cycle, run `npm run check` (TypeScript). Fix type errors before continuing. If the task touched `packages/shared/`, also run `npm run test`.
+
+This is in addition to — not instead of — the Red-Green-Refactor loop.
+
+## Override 4 — ADR review and PR body
+
+**Adds:** an ADR step before `finishing-a-development-branch` Step 4.
+
+Before presenting the finish menu, compare the implementation to the issue spec. If a notable design decision was made or changed during implementation — something a future contributor would need to understand — write an ADR using `docs/decisions/ADR-000-template.md` as the template. Number sequentially (`ADR-NNN-short-slug.md`). Set status to Proposed unless the user has already accepted it; if the PR implements an Accepted ADR, flip status in the same PR.
+
+"Notable" = a trade-off where a reasonable person could argue for a different approach. Routine implementation choices don't need an ADR.
+
+**Replaces:** `finishing-a-development-branch` Option 2 PR body template.
+
+The PR body MUST include `Closes #<issue-number>` so the issue auto-closes on merge:
+
+```bash
+gh pr create --title "<type>: <short description>" --body "$(cat <<'EOF'
+Closes #<number>
+
+## Summary
+<2-3 bullets of what changed>
+
+## Test Plan
+- [ ] <verification steps>
+EOF
+)"
+```
+
+Use Conventional Commits prefix in the title (`feat:`, `fix:`, `docs:`, `refactor:`, `test:`).
+
+## What this skill does NOT change
+
+Everything else in superpowers stays as written: the brainstorming dialogue style, the writing-plans header and task structure, the Red-Green-Refactor loop, frequent commits, the finishing-a-development-branch options menu, the test-must-pass gate. Only the four points above are overridden.
+
+## Quick reference
+
+| Phase | Standard superpowers | Sidereal override |
+|---|---|---|
+| Spec | File in `docs/superpowers/specs/` | GitHub issue body, `spec/brainstorming` label |
+| Approval gate | User reviews spec file | Human applies `spec/ready` label |
+| Branch | (not enforced) | `issue-<n>-<slug>` from `origin/main` |
+| Plan | `docs/superpowers/plans/...` | `.workspace/plans/YYYY-MM-DD-issue-<n>-<slug>.md` |
+| Per-task | TDD + commit | TDD + commit + `npm run check` |
+| Pre-PR | (none) | ADR if notable decision |
+| PR body | Summary + Test Plan | `Closes #<n>` + Summary + Test Plan |

--- a/.gitignore
+++ b/.gitignore
@@ -110,7 +110,22 @@ vite.config.ts.*
 *.backup
 *~
 
-# Skills and agent workspaces
-.agents/*
+# Agent definitions (skills view, etc.) — keep symlinks, ignore actual files
+.agent/*
+.agent/skills/*
+!.agent/skills/
+!.agent/skills/sidereal-*/
+!.agent/skills/sidereal-*/**
+
+# Working state (plans, caches, scratch) — fully ignored
+.workspace/
+
+# Claude Code project config — track settings, skills, and hooks
 .claude/*
+.claude/skills/*
 !.claude/settings.json
+!.claude/skills/
+!.claude/skills/sidereal-*/
+!.claude/skills/sidereal-*/**
+!.claude/hooks/
+!.claude/hooks/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,72 +131,20 @@ See `.env.example` and `.env.worker.example` for the full list.
 
 ## Workflow
 
-This project strictly adheres to the Jesse Vincent **Superpowers** development methodology. 
-If you are an AI agent or a subagent assisting a human developer, you MUST follow these constraints:
+This project follows the Jesse Vincent **Superpowers** development methodology, with four sidereal-specific overrides. AI agents MUST use both:
 
-### Workflow Rules
+1. **`superpowers:brainstorming`, `writing-plans`, `executing-plans` (or `subagent-driven-development`), and `finishing-a-development-branch`** — the standard methodology
+2. **`sidereal-workflow-overrides`** — the project's overlay (spec on GitHub issue, plan in `.workspace/plans/`, ADR before PR, `Closes #<n>` in PR body)
 
-1. **No Vibe Coding:** Do not touch a line of code without activating the `/brainstorm` and `/write-plan` workflows. 
-2. **Mandatory TDD:** Every single feature or bug fix must follow the Red-Green-Refactor loop. You must write a failing test first, watch it fail, write minimal code to make it pass, and commit. Code written without a test baseline will be intentionally discarded.
+When the user asks "what's next?" or starts a workflow without naming an issue, use **`sidereal-pick-next-issue`** first.
 
+### Hard rules
 
-### Phase 1 — Brainstorm
+- **No vibe coding.** Never edit code without an `spec/ready` issue and a plan file in `.workspace/plans/`.
+- **Mandatory TDD.** Every feature or bug fix follows Red-Green-Refactor. Code without a test baseline will be discarded.
+- **Never set `spec/ready` yourself.** Only a human applies that label.
 
-When a user asks you to explore or design a feature, open (or update) a GitHub issue and label it **`brainstorming`**. Use the issue to document the problem, proposed approaches, trade-offs, and open questions. The issue is the living spec — write clearly enough that a collaborator reading it cold can understand the intent and constraints.
-
-```bash
-gh issue create --title "<title>" --label brainstorming --body "<description>"
-# or update an existing issue
-gh issue edit <number> --add-label brainstorming
-```
-
-The human will iterate on the issue, ask questions, and refine it. Do not start planning or implementation until the label changes. Visual mockups must be attached to the issue for review.
-
-### Phase 2 — Branch
-
-When an issue is labelled **`implementation-ready`** (applied by a human — do not set this yourself), the spec is locked and you can begin.
-
-```bash
-gh issue list --label implementation-ready
-```
-
-Read the full issue, then create a dedicated branch:
-
-```bash
-git fetch origin
-git checkout -b issue-<number>-<short-slug> origin/main
-```
-
-### Phase 3 — Plan
-
-Write a concrete task list to `.agents/plans/YYYY-MM-DD-issue-<number>-<slug>.md`. Each task must be a single, verifiable action — no vague steps like "add error handling." Include the issue URL at the top of the plan file.
-
-`.agents/` is gitignored — plans are working documents and are never committed.
-
-### Phase 4 — Implement
-
-Work through the plan task by task. After each task:
-
-1. Run `npm run check` — fix type errors before continuing.
-2. Run `npm run test` if the task touched shared code.
-
-Commit frequently with conventional commit messages (`feat:`, `fix:`, etc.). Keep commits focused on a single logical change.
-
-### Phase 5 — ADR review
-
-When implementation is complete and all checks pass, compare the final result to the issue spec. If any significant design decision was made or changed during implementation — something a future contributor would need to understand — write an ADR before opening the PR (see **ADR Workflow** below).
-
-### Phase 6 — Pull request
-
-```bash
-gh pr create \
-  --title "<type>: <short description>" \
-  --body "Closes #<issue-number>
-
-<brief summary of what was done and any notable decisions>"
-```
-
-The `Closes #<number>` line ensures the issue is automatically closed when the PR merges.
+See the `sidereal-workflow-overrides` skill for the full override details.
 
 ## Decision Records
 


### PR DESCRIPTION
## Summary

- Replace the long inline workflow section in `AGENTS.md` with two project-level skills that overlay the superpowers methodology, plus warn-only PreToolUse hooks that surface drift at edit and PR-create time.
- New skills (`.claude/skills/sidereal-*`): `sidereal-workflow-overrides` (spec on GitHub issue, plan in `.workspace/plans/`, ADR before PR, `Closes #<n>` in PR body) and `sidereal-pick-next-issue` (recommends from `spec/ready` queue by priority then age).
- New hooks (`.claude/hooks/`): `check-edit-prerequisites.sh` warns when editing without an `issue-<n>-*` branch, `spec/ready` label, or matching plan file; `check-pr-closes-issue.sh` warns when `gh pr create` lacks `Closes #<n>`. Both are warn-only — observe usage before tightening to blocking.
- Reorg working dirs: `.agent/skills/` (symlinked view of definitions) and `.workspace/{plans,cache}/` (ephemeral state). Distinct names avoid the `.agent` vs `.agents` typo collision; `.workspace/` is gitignored.

## Test plan

- [ ] Open a fresh Claude Code session in this repo and confirm both `sidereal-workflow-overrides` and `sidereal-pick-next-issue` appear in the available-skills list.
- [ ] Trigger `check-edit-prerequisites.sh` by attempting an edit on `main` — verify the warning fires and exits 0.
- [ ] On a properly-named `issue-<n>-*` branch with a matching plan in `.workspace/plans/`, verify no warning.
- [ ] Run `gh pr create` with and without `Closes #<n>` in the body and confirm the second hook warns appropriately.
- [ ] Confirm `.workspace/` stays untracked and `.claude/skills/sidereal-*/` + `.claude/hooks/` are tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)