### PR TITLE
fix: restore main branch build condition in docker-build-push workflow

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -146,10 +146,10 @@ jobs:
           echo "### Security Scan" >> $GITHUB_STEP_SUMMARY
           echo "Trivy results uploaded to GitHub Security tab" >> $GITHUB_STEP_SUMMARY
 
-  # Stable branch: build each platform on a native runner, no QEMU
+  # Main branch: build each platform on a native runner, no QEMU
   build:
     needs: typecheck
-    if: github.event_name != 'pull_request' && github.ref_name == 'v0.x'
+    if: github.event_name != 'pull_request'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
PR #160 accidentally changed the `build` job condition to `github.ref_name == 'v0.x'`, which means the multi-arch Docker image build and Trivy security scan have not been running on pushes to `main` since that merge. This restores the original condition (`github.event_name != 'pull_request'`).

**Impact:** Without this fix, no new Docker images are published to GHCR on main pushes, and code scanning alerts from Trivy are stale.