### PR TITLE
feat: dual-write source fields and add getImageBySource query

### DIFF
--- a/apps/server/src/services/storage.ts
+++ b/apps/server/src/services/storage.ts
@@ -4,6 +4,7 @@ import { like, or } from 'drizzle-orm';
 import { imageStorage } from './image-storage';
 import type { AstroImage, InsertAstroImage, Equipment, InsertEquipment, ImageEquipment, InsertImageEquipment, PlateSolvingJob, InsertPlateSolvingJob, EquipmentGroup, InsertEquipmentGroup, EquipmentGroupMember, InsertEquipmentGroupMember, Location, InsertLocation, ImageAcquisitionRow, InsertImageAcquisitionRow, CatalogObject, InsertCatalogObject, UserTarget } from "@shared/types";
 import { computeImageSummary, groupAndEnrichTargets } from '@shared/image-utils';
+import { withSourceDefaults } from '@shared/utils/source';
 
 class DbStorage {
   // Astrophotography images
@@ -63,8 +64,19 @@ class DbStorage {
     return result[0] || undefined;
   }
 
+  async getImageBySource(sourceType: string, sourceId: string): Promise<AstroImage | undefined> {
+    const result = await db.select().from(schema.astrophotographyImages)
+      .where(and(
+        eq(schema.astrophotographyImages.sourceType, sourceType),
+        eq(schema.astrophotographyImages.sourceId, sourceId),
+      ))
+      .execute();
+    return result[0] || undefined;
+  }
+
   async createAstroImage(image: InsertAstroImage): Promise<AstroImage> {
-    const result = await db.insert(schema.astrophotographyImages).values(image).returning().execute();
+    const values = withSourceDefaults(image);
+    const result = await db.insert(schema.astrophotographyImages).values(values).returning().execute();
     if (!result[0]) {
       throw new Error('Failed to create astro image');
     }


### PR DESCRIPTION
## Summary
- Wires `withSourceDefaults` into `createAstroImage` so every new row gets `source_type` and `source_id` populated automatically from `immich_id`
- Adds `getImageBySource(sourceType, sourceId)` query to `DbStorage` for future source-agnostic lookups
- Completes Task 5 (final task) of issue #111 — the schema columns, migrations, and `withSourceDefaults` helper were added in earlier tasks

Closes #166

## Test Plan
- [ ] `npm run check` passes (excluding pre-existing `sync-beads-github` type errors)
- [ ] `npm run test` passes — 7/7 including 4 `withSourceDefaults` unit tests
- [ ] Smoke-test: new rows written via Immich sync have `source_type='immich'` and `source_id == immich_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)