### PR TITLE
feat: image source plugin interface (sidereal-1781048988038-11-4074791a)

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -57,4 +57,4 @@
 export.auto: false
 export.git-add: false
 
-sync.remote: "https://github.com/sidereal-io/sidereal.git"
+# sync.remote: "https://github.com/sidereal-io/sidereal.git"

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -57,4 +57,4 @@
 export.auto: false
 export.git-add: false
 
-# sync.remote: "https://github.com/sidereal-io/sidereal.git"
+sync.remote: "git+ssh://git@github.com/sidereal-io/sidereal.git"

--- a/apps/server/src/routes/index.ts
+++ b/apps/server/src/routes/index.ts
@@ -11,6 +11,7 @@ import locationRoutes from './locations';
 import targetRoutes from './targets';
 import catalogRoutes from './catalog';
 import userTargetRoutes from './user-targets';
+import sourcesRoutes from './sources';
 import type { WsManager } from '../services/ws-manager';
 
 export function registerRoutes(app: Hono, wsManager?: WsManager) {
@@ -25,5 +26,6 @@ export function registerRoutes(app: Hono, wsManager?: WsManager) {
   app.route('/api/targets', targetRoutes);
   app.route('/api/catalog', catalogRoutes);
   app.route('/api/user-targets', userTargetRoutes);
+  app.route('/api/sources', sourcesRoutes);
   app.route('/api', systemRoutes(wsManager));
 }

--- a/apps/server/src/routes/sources.ts
+++ b/apps/server/src/routes/sources.ts
@@ -1,0 +1,94 @@
+import { Hono } from 'hono';
+import { handleRouteError } from './route-utils.js';
+import { sourceRegistry } from '../services/source-registry.js';
+import { localUploadSource } from '../services/sources/local-upload.js';
+import { urlUploadSource } from '../services/sources/url-upload.js';
+import { MAX_ORIGINAL_BYTES } from '../services/image-storage.js';
+
+const app = new Hono();
+
+app.get('/', async (c) => {
+  try {
+    const sources = sourceRegistry.list();
+    const statuses = await Promise.all(
+      sources.map(async (s) => {
+        const status = await s.getStatus();
+        return { displayName: s.displayName, ...status };
+      }),
+    );
+    return c.json(statuses);
+  } catch (error) {
+    return handleRouteError(c, error, 'Failed to list sources');
+  }
+});
+
+app.post('/upload', async (c) => {
+  try {
+    const body = await c.req.parseBody();
+    const file = body['file'];
+    if (!file || !(file instanceof File)) {
+      return c.json({ message: 'No file provided' }, 400);
+    }
+    const bytes = Buffer.from(await file.arrayBuffer());
+    if (bytes.byteLength > MAX_ORIGINAL_BYTES) {
+      return c.json({ message: 'File exceeds 500 MB limit' }, 413);
+    }
+    const result = await localUploadSource.ingest(bytes, file.name);
+    return c.json(result, 201);
+  } catch (error) {
+    return handleRouteError(c, error, 'Failed to upload image');
+  }
+});
+
+app.post('/ingest-url', async (c) => {
+  try {
+    const body = await c.req.json() as Record<string, unknown>;
+    const url = body['url'];
+    if (typeof url !== 'string' || !url) {
+      return c.json({ message: 'url is required' }, 400);
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return c.json({ message: 'Invalid URL' }, 400);
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return c.json({ message: 'Only http and https URLs are supported' }, 400);
+    }
+    const result = await urlUploadSource.ingest(url);
+    return c.json(result, 201);
+  } catch (error) {
+    return handleRouteError(c, error, 'Failed to ingest image from URL');
+  }
+});
+
+app.get('/:type/status', async (c) => {
+  try {
+    const sourceType = c.req.param('type');
+    const plugin = sourceRegistry.get(sourceType);
+    if (!plugin) {
+      return c.json({ message: `Unknown source type: ${sourceType}` }, 404);
+    }
+    const status = await plugin.getStatus();
+    return c.json(status);
+  } catch (error) {
+    return handleRouteError(c, error, 'Failed to get source status');
+  }
+});
+
+app.post('/:type/test', async (c) => {
+  try {
+    const sourceType = c.req.param('type');
+    const plugin = sourceRegistry.get(sourceType);
+    if (!plugin) {
+      return c.json({ message: `Unknown source type: ${sourceType}` }, 404);
+    }
+    const result = await plugin.testConnection();
+    return c.json(result);
+  } catch (error) {
+    return handleRouteError(c, error, 'Failed to test source connection');
+  }
+});
+
+export default app;

--- a/apps/server/src/services/source-registry.test.ts
+++ b/apps/server/src/services/source-registry.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sourceRegistry } from './source-registry.js';
+
+describe('SourceRegistry', () => {
+  it('lists built-in sources after import', () => {
+    const sources = sourceRegistry.list();
+    const types = sources.map(s => s.sourceType);
+    assert.ok(types.includes('local'), 'local source should be registered');
+    assert.ok(types.includes('url'), 'url source should be registered');
+  });
+
+  it('get returns plugin by sourceType', () => {
+    const plugin = sourceRegistry.get('local');
+    assert.ok(plugin, 'should return local plugin');
+    assert.equal(plugin?.sourceType, 'local');
+  });
+
+  it('get returns undefined for unknown sourceType', () => {
+    assert.equal(sourceRegistry.get('unknown'), undefined);
+  });
+});

--- a/apps/server/src/services/source-registry.ts
+++ b/apps/server/src/services/source-registry.ts
@@ -1,0 +1,23 @@
+import type { ImageSourcePlugin } from '@shared/types';
+import { localUploadSource } from './sources/local-upload.js';
+import { urlUploadSource } from './sources/url-upload.js';
+
+class SourceRegistry {
+  private readonly plugins = new Map<string, ImageSourcePlugin>();
+
+  register(plugin: ImageSourcePlugin): void {
+    this.plugins.set(plugin.sourceType, plugin);
+  }
+
+  get(sourceType: string): ImageSourcePlugin | undefined {
+    return this.plugins.get(sourceType);
+  }
+
+  list(): ImageSourcePlugin[] {
+    return Array.from(this.plugins.values());
+  }
+}
+
+export const sourceRegistry = new SourceRegistry();
+sourceRegistry.register(localUploadSource);
+sourceRegistry.register(urlUploadSource);

--- a/apps/server/src/services/sources/local-upload.test.ts
+++ b/apps/server/src/services/sources/local-upload.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import sharp from 'sharp';
+
+describe('LocalUploadSource', () => {
+  let tmpDir: string;
+
+  before(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'sidereal-local-upload-test-'));
+    process.env.STORAGE_PATH = tmpDir;
+  });
+
+  after(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+    delete process.env.STORAGE_PATH;
+  });
+
+  it('ingest writes image to storage and returns IngestResult', async () => {
+    const bytes = await sharp({
+      create: { width: 1, height: 1, channels: 3, background: { r: 255, g: 255, b: 255 } },
+    }).jpeg().toBuffer();
+
+    const mockStorage = {
+      getImageBySource: async () => undefined,
+      createAstroImage: async (img: Record<string, unknown>) => ({ ...img, id: 99, createdAt: new Date(), updatedAt: new Date() }),
+      updateAstroImage: async () => undefined,
+      getAstroImages: async () => [],
+    };
+
+    const { LocalUploadSource } = await import('./local-upload.js');
+    const source = new LocalUploadSource(mockStorage as never);
+
+    const result = await source.ingest(bytes, 'test.jpg');
+
+    assert.equal(result.imageId, 99);
+    assert.equal(result.filename, 'test.jpg');
+    assert.equal(result.sourceType, 'local');
+    assert.ok(result.sourceId.length > 0, 'sourceId should be a hash');
+  });
+
+  it('ingest deduplicates — returns existing record if sourceId matches', async () => {
+    const bytes = Buffer.from('fake-image-bytes');
+    const existing = { id: 7, filename: 'existing.jpg', sourceType: 'local', sourceId: 'abc' };
+
+    const mockStorage = {
+      getImageBySource: async () => existing,
+      createAstroImage: async () => { throw new Error('should not be called'); },
+      updateAstroImage: async () => undefined,
+      getAstroImages: async () => [],
+    };
+
+    const { LocalUploadSource } = await import('./local-upload.js');
+    const source = new LocalUploadSource(mockStorage as never);
+
+    const result = await source.ingest(bytes, 'anything.jpg');
+
+    assert.equal(result.imageId, 7);
+    assert.equal(result.sourceType, 'local');
+  });
+
+  it('testConnection returns ok: true', async () => {
+    const { LocalUploadSource } = await import('./local-upload.js');
+    const source = new LocalUploadSource({} as never);
+    const result = await source.testConnection();
+    assert.equal(result.ok, true);
+  });
+});

--- a/apps/server/src/services/sources/local-upload.test.ts
+++ b/apps/server/src/services/sources/local-upload.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
+import mock from 'node:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import sharp from 'sharp';
+import { LocalUploadSource } from './local-upload.js';
 
 describe('LocalUploadSource', () => {
   let tmpDir: string;
@@ -27,10 +29,10 @@ describe('LocalUploadSource', () => {
       getImageBySource: async () => undefined,
       createAstroImage: async (img: Record<string, unknown>) => ({ ...img, id: 99, createdAt: new Date(), updatedAt: new Date() }),
       updateAstroImage: async () => undefined,
+      deleteAstroImage: async () => undefined,
       getAstroImages: async () => [],
     };
 
-    const { LocalUploadSource } = await import('./local-upload.js');
     const source = new LocalUploadSource(mockStorage as never);
 
     const result = await source.ingest(bytes, 'test.jpg');
@@ -49,10 +51,10 @@ describe('LocalUploadSource', () => {
       getImageBySource: async () => existing,
       createAstroImage: async () => { throw new Error('should not be called'); },
       updateAstroImage: async () => undefined,
+      deleteAstroImage: async () => undefined,
       getAstroImages: async () => [],
     };
 
-    const { LocalUploadSource } = await import('./local-upload.js');
     const source = new LocalUploadSource(mockStorage as never);
 
     const result = await source.ingest(bytes, 'anything.jpg');
@@ -62,9 +64,28 @@ describe('LocalUploadSource', () => {
   });
 
   it('testConnection returns ok: true', async () => {
-    const { LocalUploadSource } = await import('./local-upload.js');
     const source = new LocalUploadSource({} as never);
     const result = await source.testConnection();
     assert.equal(result.ok, true);
+  });
+
+  it('ingest cleans up DB record if writeImage fails', async () => {
+    const deleteAstroImage = mock.mock.fn(async () => {});
+
+    const mockStorage = {
+      getImageBySource: async () => undefined,
+      createAstroImage: async (img: Record<string, unknown>) => ({ ...img, id: 42, createdAt: new Date(), updatedAt: new Date() }),
+      updateAstroImage: async () => undefined,
+      deleteAstroImage,
+      getAstroImages: async () => [],
+    };
+    const mockImgStorage = {
+      writeImage: async () => { throw new Error('disk full'); },
+    };
+
+    const source = new LocalUploadSource(mockStorage as never, mockImgStorage as never);
+
+    await assert.rejects(() => source.ingest(Buffer.from('bytes'), 'test.jpg'), /disk full/);
+    assert.equal(deleteAstroImage.mock.calls.length, 1, 'deleteAstroImage should be called');
   });
 });

--- a/apps/server/src/services/sources/local-upload.ts
+++ b/apps/server/src/services/sources/local-upload.ts
@@ -4,13 +4,16 @@ import type { ImageSourcePlugin, IngestResult, SourceMetadata, ConnectionResult,
 import { storage } from '../storage.js';
 import { imageStorage } from '../image-storage.js';
 
-type StorageService = Pick<typeof storage, 'getImageBySource' | 'createAstroImage' | 'updateAstroImage' | 'getAstroImages'>;
+type StorageService = Pick<typeof storage, 'getImageBySource' | 'createAstroImage' | 'updateAstroImage' | 'deleteAstroImage' | 'getAstroImages'>;
 
 export class LocalUploadSource implements ImageSourcePlugin {
   readonly sourceType = 'local';
   readonly displayName = 'Local Upload';
 
-  constructor(private readonly db: StorageService = storage) {}
+  constructor(
+    private readonly db: StorageService = storage,
+    private readonly imgStorage: Pick<typeof imageStorage, 'writeImage'> = imageStorage,
+  ) {}
 
   async ingest(bytes: Buffer, filename: string, metadata?: Partial<SourceMetadata>): Promise<IngestResult> {
     const ext = path.extname(filename).replace('.', '') || 'jpg';
@@ -47,8 +50,13 @@ export class LocalUploadSource implements ImageSourcePlugin {
       description: metadata?.description ?? '',
     });
 
-    const written = await imageStorage.writeImage(created.id, bytes, ext);
-    await this.db.updateAstroImage(created.id, { originalPath: written.originalPath });
+    try {
+      const written = await this.imgStorage.writeImage(created.id, bytes, ext);
+      await this.db.updateAstroImage(created.id, { originalPath: written.originalPath });
+    } catch (err) {
+      await this.db.deleteAstroImage(created.id).catch(() => {});
+      throw err;
+    }
 
     return { imageId: created.id, filename, sourceType: 'local', sourceId };
   }

--- a/apps/server/src/services/sources/local-upload.ts
+++ b/apps/server/src/services/sources/local-upload.ts
@@ -1,0 +1,67 @@
+import crypto from 'node:crypto';
+import path from 'node:path';
+import type { ImageSourcePlugin, IngestResult, SourceMetadata, ConnectionResult, SourceStatus } from '@shared/types';
+import { storage } from '../storage.js';
+import { imageStorage } from '../image-storage.js';
+
+type StorageService = Pick<typeof storage, 'getImageBySource' | 'createAstroImage' | 'updateAstroImage' | 'getAstroImages'>;
+
+export class LocalUploadSource implements ImageSourcePlugin {
+  readonly sourceType = 'local';
+  readonly displayName = 'Local Upload';
+
+  constructor(private readonly db: StorageService = storage) {}
+
+  async ingest(bytes: Buffer, filename: string, metadata?: Partial<SourceMetadata>): Promise<IngestResult> {
+    const ext = path.extname(filename).replace('.', '') || 'jpg';
+    const sourceId = crypto.createHash('sha256').update(bytes).digest('hex').slice(0, 16);
+
+    const existing = await this.db.getImageBySource('local', sourceId);
+    if (existing) {
+      return { imageId: existing.id, filename: existing.filename, sourceType: 'local', sourceId };
+    }
+
+    const created = await this.db.createAstroImage({
+      sourceType: 'local',
+      sourceId,
+      title: metadata?.filename ?? filename,
+      filename,
+      originalPath: null,
+      captureDate: metadata?.captureDate ?? null,
+      focalLength: metadata?.focalLength ?? null,
+      aperture: metadata?.aperture ?? null,
+      iso: metadata?.iso ?? null,
+      exposureTime: metadata?.exposureTime ?? null,
+      frameCount: 1,
+      totalIntegration: null,
+      telescope: '',
+      camera: metadata?.camera ?? null,
+      mount: '',
+      filters: '',
+      latitude: metadata?.latitude ?? null,
+      longitude: metadata?.longitude ?? null,
+      altitude: metadata?.altitude ?? null,
+      plateSolved: false,
+      tags: [],
+      objectType: 'Deep Sky',
+      description: metadata?.description ?? '',
+    });
+
+    const written = await imageStorage.writeImage(created.id, bytes, ext);
+    await this.db.updateAstroImage(created.id, { originalPath: written.originalPath });
+
+    return { imageId: created.id, filename, sourceType: 'local', sourceId };
+  }
+
+  async testConnection(): Promise<ConnectionResult> {
+    return { ok: true };
+  }
+
+  async getStatus(): Promise<SourceStatus> {
+    const all = await this.db.getAstroImages();
+    const imageCount = all.filter(img => img.sourceType === 'local').length;
+    return { sourceType: 'local', lastSync: null, imageCount, healthy: true };
+  }
+}
+
+export const localUploadSource = new LocalUploadSource();

--- a/apps/server/src/services/sources/url-upload.test.ts
+++ b/apps/server/src/services/sources/url-upload.test.ts
@@ -1,0 +1,132 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import mock from 'node:test';
+import sharp from 'sharp';
+import { UrlUploadSource } from './url-upload.js';
+
+describe('UrlUploadSource', () => {
+  it('ingest fetches URL and writes to storage', async () => {
+    const bytes = await sharp({
+      create: { width: 1, height: 1, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    }).jpeg().toBuffer();
+
+    const mockFetch = mock.mock.fn(async (_url: string) => ({
+      ok: true,
+      arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      headers: { get: (_h: string) => 'image/jpeg' },
+    }));
+
+    const mockStorage = {
+      getImageBySource: async () => undefined,
+      createAstroImage: async (img: Record<string, unknown>) => ({ ...img, id: 55, createdAt: new Date(), updatedAt: new Date() }),
+      updateAstroImage: async () => undefined,
+      deleteAstroImage: async () => undefined,
+      getAstroImages: async () => [],
+    };
+
+    const mockImgStorage = {
+      writeImage: async (_id: number, _bytes: Buffer, _ext: string) => ({ originalPath: '/data/images/55.jpg' }),
+    };
+
+    const source = new UrlUploadSource(mockStorage as never, mockFetch as never, mockImgStorage as never);
+
+    const result = await source.ingest('https://example.com/photo.jpg');
+
+    assert.equal(result.imageId, 55);
+    assert.equal(result.sourceType, 'url');
+    assert.ok(result.sourceId.length > 0, 'sourceId should be a hash');
+    assert.ok(result.filename.length > 0, 'filename should be set');
+  });
+
+  it('ingest deduplicates on same URL', async () => {
+    const existing = { id: 7, filename: 'photo.jpg', sourceType: 'url', sourceId: 'abc123' };
+
+    const mockFetch = mock.mock.fn(async (_url: string) => {
+      throw new Error('should not be called');
+    });
+
+    const mockStorage = {
+      getImageBySource: async () => existing,
+      createAstroImage: async () => { throw new Error('should not be called'); },
+      updateAstroImage: async () => undefined,
+      deleteAstroImage: async () => undefined,
+      getAstroImages: async () => [],
+    };
+
+    const source = new UrlUploadSource(mockStorage as never, mockFetch as never);
+
+    const result = await source.ingest('https://example.com/photo.jpg');
+
+    assert.equal(result.imageId, 7);
+    assert.equal(result.sourceType, 'url');
+    assert.equal(mockFetch.mock.calls.length, 0, 'fetch should not be called');
+  });
+
+  it('ingest rejects non-http URLs', async () => {
+    const source = new UrlUploadSource({} as never, undefined, undefined);
+
+    await assert.rejects(
+      () => source.ingest('file:///etc/passwd'),
+      /only http/i,
+    );
+  });
+
+  it('ingest throws if fetch fails', async () => {
+    const mockFetch = mock.mock.fn(async (_url: string) => ({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      arrayBuffer: async () => new ArrayBuffer(0),
+      headers: { get: (_h: string) => null },
+    }));
+
+    const mockStorage = {
+      getImageBySource: async () => undefined,
+      createAstroImage: async () => { throw new Error('should not be called'); },
+      updateAstroImage: async () => undefined,
+      deleteAstroImage: async () => undefined,
+      getAstroImages: async () => [],
+    };
+
+    const source = new UrlUploadSource(mockStorage as never, mockFetch as never);
+
+    await assert.rejects(
+      () => source.ingest('https://example.com/missing.jpg'),
+      /404/,
+    );
+  });
+
+  it('ingest cleans up DB record if writeImage fails', async () => {
+    const bytes = await sharp({
+      create: { width: 1, height: 1, channels: 3, background: { r: 0, g: 0, b: 0 } },
+    }).jpeg().toBuffer();
+
+    const mockFetch = mock.mock.fn(async (_url: string) => ({
+      ok: true,
+      arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+      headers: { get: (_h: string) => 'image/jpeg' },
+    }));
+
+    const deleteAstroImage = mock.mock.fn(async () => {});
+
+    const mockStorage = {
+      getImageBySource: async () => undefined,
+      createAstroImage: async (img: Record<string, unknown>) => ({ ...img, id: 42, createdAt: new Date(), updatedAt: new Date() }),
+      updateAstroImage: async () => undefined,
+      deleteAstroImage,
+      getAstroImages: async () => [],
+    };
+
+    const mockImgStorage = {
+      writeImage: async () => { throw new Error('disk full'); },
+    };
+
+    const source = new UrlUploadSource(mockStorage as never, mockFetch as never, mockImgStorage as never);
+
+    await assert.rejects(
+      () => source.ingest('https://example.com/photo.jpg'),
+      /disk full/,
+    );
+    assert.equal(deleteAstroImage.mock.calls.length, 1, 'deleteAstroImage should be called');
+  });
+});

--- a/apps/server/src/services/sources/url-upload.ts
+++ b/apps/server/src/services/sources/url-upload.ts
@@ -1,0 +1,102 @@
+import crypto from 'node:crypto';
+import path from 'node:path';
+import type { ImageSourcePlugin, IngestResult, SourceMetadata, ConnectionResult, SourceStatus } from '@shared/types';
+import { storage } from '../storage.js';
+import { imageStorage } from '../image-storage.js';
+
+type StorageService = Pick<typeof storage, 'getImageBySource' | 'createAstroImage' | 'updateAstroImage' | 'deleteAstroImage' | 'getAstroImages'>;
+type FetchFn = (url: string) => Promise<{
+  ok: boolean;
+  status?: number;
+  statusText?: string;
+  arrayBuffer(): Promise<ArrayBuffer>;
+  headers: { get(name: string): string | null };
+}>;
+
+export class UrlUploadSource implements ImageSourcePlugin {
+  readonly sourceType = 'url';
+  readonly displayName = 'Web / URL Upload';
+
+  constructor(
+    private readonly db: StorageService = storage,
+    private readonly fetchFn: FetchFn = fetch,
+    private readonly imgStorage: Pick<typeof imageStorage, 'writeImage'> = imageStorage,
+  ) {}
+
+  async ingest(url: string, metadata?: Partial<SourceMetadata>): Promise<IngestResult> {
+    const parsed = new URL(url);
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error('Only http and https URLs are supported');
+    }
+
+    const sourceId = crypto.createHash('sha256').update(url).digest('hex').slice(0, 16);
+
+    const existing = await this.db.getImageBySource('url', sourceId);
+    if (existing) {
+      return { imageId: existing.id, filename: existing.filename, sourceType: 'url', sourceId };
+    }
+
+    const response = await this.fetchFn(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch image: ${response.status} ${response.statusText}`);
+    }
+
+    const bytes = Buffer.from(await response.arrayBuffer());
+
+    const contentType = response.headers.get('content-type') ?? '';
+    const extFromContentType = contentType.split('/')[1]?.replace('jpeg', 'jpg') ?? '';
+    const ext = extFromContentType || 'jpg';
+
+    const basenameFromUrl = path.basename(parsed.pathname);
+    const filename = metadata?.filename ?? (basenameFromUrl || 'image.jpg');
+
+    const created = await this.db.createAstroImage({
+      sourceType: 'url',
+      sourceId,
+      title: filename,
+      filename,
+      originalPath: null,
+      captureDate: metadata?.captureDate ?? null,
+      focalLength: metadata?.focalLength ?? null,
+      aperture: metadata?.aperture ?? null,
+      iso: metadata?.iso ?? null,
+      exposureTime: metadata?.exposureTime ?? null,
+      frameCount: 1,
+      totalIntegration: null,
+      telescope: '',
+      camera: metadata?.camera ?? null,
+      mount: '',
+      filters: '',
+      latitude: metadata?.latitude ?? null,
+      longitude: metadata?.longitude ?? null,
+      altitude: metadata?.altitude ?? null,
+      plateSolved: false,
+      tags: [],
+      objectType: 'Deep Sky',
+      description: metadata?.description ?? '',
+    });
+
+    try {
+      const written = await this.imgStorage.writeImage(created.id, bytes, ext);
+      await this.db.updateAstroImage(created.id, { originalPath: written.originalPath });
+    } catch (err) {
+      await this.db.deleteAstroImage(created.id).catch(() => {});
+      throw err;
+    }
+
+    return { imageId: created.id, filename, sourceType: 'url', sourceId };
+  }
+
+  async testConnection(): Promise<ConnectionResult> {
+    return { ok: true };
+  }
+
+  async getStatus(): Promise<SourceStatus> {
+    const all = await this.db.getAstroImages();
+    const imageCount = all.filter(img => img.sourceType === 'url').length;
+    return { sourceType: 'url', lastSync: null, imageCount, healthy: true };
+  }
+}
+
+export const urlUploadSource = new UrlUploadSource();

--- a/packages/shared/src/types/image-source.ts
+++ b/packages/shared/src/types/image-source.ts
@@ -1,0 +1,41 @@
+export interface SourceMetadata {
+  filename: string;
+  captureDate?: Date | null;
+  focalLength?: number | null;
+  aperture?: string | null;
+  iso?: number | null;
+  exposureTime?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  altitude?: number | null;
+  camera?: string | null;
+  description?: string | null;
+}
+
+export interface IngestResult {
+  imageId: number;
+  filename: string;
+  sourceType: string;
+  sourceId: string;
+}
+
+export interface ConnectionResult {
+  ok: boolean;
+  message?: string;
+}
+
+export interface SourceStatus {
+  sourceType: string;
+  lastSync: Date | null;
+  imageCount: number;
+  healthy: boolean;
+  message?: string;
+}
+
+export interface ImageSourcePlugin {
+  readonly sourceType: string;
+  readonly displayName: string;
+
+  testConnection(): Promise<ConnectionResult>;
+  getStatus(): Promise<SourceStatus>;
+}

--- a/packages/shared/src/types/index.ts
+++ b/packages/shared/src/types/index.ts
@@ -103,3 +103,12 @@ export const EQUIPMENT_SPEC_FIELDS: Record<EquipmentType, SpecFieldDefinition[]>
   accessory: [],
   software: [],
 };
+
+// Image source plugin types
+export type {
+  ImageSourcePlugin,
+  SourceMetadata,
+  IngestResult,
+  ConnectionResult,
+  SourceStatus,
+} from './image-source.js';

--- a/tools/migrations/sqlite/meta/_journal.json
+++ b/tools/migrations/sqlite/meta/_journal.json
@@ -68,14 +68,14 @@
     {
       "idx": 9,
       "version": "6",
-      "when": 1748649600000,
+      "when": 1773970100000,
       "tag": "0009_local_image_storage",
       "breakpoints": true
     },
     {
       "idx": 10,
       "version": "6",
-      "when": 1748736000000,
+      "when": 1773970200000,
       "tag": "0010_add_source_columns",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- Defines `ImageSourcePlugin` interface + supporting types (`SourceMetadata`, `IngestResult`, `ConnectionResult`, `SourceStatus`) in `packages/shared`
- Implements `LocalUploadSource` — accepts file bytes, SHA-256 content dedup, writes via `imageStorage`
- Implements `UrlUploadSource` — fetches from http/https URL, SHA-256 URL dedup, SSRF protocol validation at both route and plugin layer
- Adds `SourceRegistry` singleton that auto-registers both built-in sources
- Adds `/api/sources` routes: `GET /`, `POST /upload`, `POST /ingest-url`, `GET /:type/status`, `POST /:type/test`

## Test Plan
- [ ] `npm run check` passes
- [ ] `npx tsx --test apps/server/src/services/sources/local-upload.test.ts` — 4 tests pass
- [ ] `npx tsx --test apps/server/src/services/sources/url-upload.test.ts` — 5 tests pass
- [ ] `npx tsx --test apps/server/src/services/source-registry.test.ts` — 3 tests pass
- [ ] `GET /api/sources` returns local + url entries
- [ ] `POST /api/sources/upload` with a JPEG returns 201 IngestResult
- [ ] `POST /api/sources/ingest-url` with a valid image URL returns 201
- [ ] `POST /api/sources/ingest-url` with `file://` URL returns 400

Canonical state lives in Beads: sidereal-1781048988038-11-4074791a