### PR TITLE
Make server tests runnable + CI-gated; fill ImmichImageSource test gaps (sidereal-pd9)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run unit tests
         run: npm run test
 
+      - name: Run server tests
+        run: npm run test:server
+
       - name: Build all packages
         run: npm run build
 

--- a/apps/server/src/db.ts
+++ b/apps/server/src/db.ts
@@ -69,7 +69,9 @@ async function initializeDatabase() {
   initialized = true;
 }
 
-// Initialize immediately
-await initializeDatabase();
+// Initialize immediately (skipped when SKIP_DB_INIT=1, e.g. during unit tests)
+if (process.env.SKIP_DB_INIT !== '1') {
+  await initializeDatabase();
+}
 
 export { db, schema, sqliteDbPath };

--- a/apps/server/src/services/sources/immich.test.ts
+++ b/apps/server/src/services/sources/immich.test.ts
@@ -82,4 +82,43 @@ describe('ImmichImageSource.testConnection', () => {
     assert.equal(result.ok, false, 'should return ok:false');
     assert.equal(result.message, 'Immich returned status 401', 'should include status in message');
   });
+
+  it('returns ok:true on 200', async () => {
+    const fetchFn = mock.mock.fn(async () => jsonResponse([]));
+    const src = new ImmichImageSource(makeDb() as never, { writeImage: mock.mock.fn() } as never, cfg as never, fetchFn as never);
+    assert.deepEqual(await src.testConnection(), { ok: true });
+  });
+});
+
+describe('ImmichImageSource.getStatus', () => {
+  it('counts only immich-sourced images', async () => {
+    const db = makeDb([
+      { id: 1, sourceType: 'immich', sourceId: 'a1', filename: 'x', originalPath: '/p/1' },
+      { id: 2, sourceType: 'local',  sourceId: 'l1', filename: 'y', originalPath: '/p/2' },
+      { id: 3, sourceType: 'immich', sourceId: 'a2', filename: 'z', originalPath: '/p/3' },
+    ]);
+    const src = new ImmichImageSource(db as never, { writeImage: mock.mock.fn() } as never, cfg as never, mock.mock.fn() as never);
+    const status = await src.getStatus();
+    assert.equal(status.sourceType, 'immich');
+    assert.equal(status.imageCount, 2);
+  });
+});
+
+describe('ImmichImageSource.sync (album mode)', () => {
+  it('ingests assets from selected albums', async () => {
+    const albumCfg = { getImmichConfig: mock.mock.fn(async () => ({ host: 'http://immich.test', apiKey: 'k', syncByAlbum: true, selectedAlbumIds: ['alb1'] })) };
+    const db = makeDb();
+    const imgStorage = { writeImage: mock.mock.fn(async (id: number) => ({ originalPath: `/p/${id}.fit` })) };
+    const fetchFn = mock.mock.fn(async (url: string) => {
+      if (url === 'http://immich.test/api/albums') return jsonResponse([{ id: 'alb1', albumName: 'A', assetCount: 1 }]);
+      if (url === 'http://immich.test/api/albums/alb1') return jsonResponse({ assets: [{ id: 'a1', originalFileName: 'a1.fit', exifInfo: {} }] });
+      if (url.includes('/api/assets/')) return bytesResponse(new Uint8Array([1, 2, 3]).buffer);
+      return jsonResponse({});
+    });
+    const src = new ImmichImageSource(db as never, imgStorage as never, albumCfg as never, fetchFn as never);
+    const r = await src.sync();
+    assert.equal(r.syncedCount, 1);
+    assert.equal(db.rows[0]?.sourceType, 'immich');
+    assert.equal(db.rows[0]?.sourceId, 'a1');
+  });
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "docker:logs": "docker compose logs -f",
     "check": "tsc",
     "test": "tsx --test packages/shared/src/**/*.test.ts",
+    "test:server": "SKIP_DB_INIT=1 tsx --test \"apps/server/src/**/*.test.ts\"",
     "test:scripts": "tsx --test \"tools/scripts/sync-beads-github/**/*.test.ts\"",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",


### PR DESCRIPTION
Implements bead `sidereal-pd9` — a follow-up discovered during the Immich plugin work (#191).

## Problem
Server unit tests under `apps/server/src/**/*.test.ts` couldn't run and weren't CI-gated. Importing any module-under-test transitively loaded `apps/server/src/db.ts`, whose top-level `await initializeDatabase()` connected to SQLite + ran migrations *at import time* and threw under `tsx --test`.

## Changes (child beads .1–.2)
- **`.1`** Guard the import-time init: `db.ts` only runs `initializeDatabase()` when `SKIP_DB_INIT !== '1'` (init-by-default; dev/prod/Docker/normal-CI startup byte-for-byte unchanged). Added `test:server` script (`SKIP_DB_INIT=1 tsx --test "apps/server/src/**/*.test.ts"`) and a CI step in `ci.yml`. All six existing server test files now run — 29 tests green, no test modifications needed.
- **`.2`** Filled `ImmichImageSource` coverage gaps: `testConnection()` success, `getStatus()` counting only `immich`-sourced rows, and album-mode `sync()` ingest — suite now 32 tests.

Tests inject their own DB fakes, so skipping real init is exactly right; the methods under test run fully.

## Testing
`npm run check` clean for `apps/` (only pre-existing `tools/scripts/sync-beads-github/github.ts` errors remain). `npm run test` (shared) 7/7. `npm run test:server` 32/32 across 6 files. CI now runs `test:server` on every PR.

## Non-goals
Diagnosing the underlying `migrate()`/`better-sqlite3` failure under `tsx --test` (only relevant for real-DB integration tests, which this doesn't add); converting `db.ts` to lazy accessors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)